### PR TITLE
BREAKING CHANGE: add option to download all attachments or a comma-separated list of attachment IDs

### DIFF
--- a/nodes/Imap/operations/email/functions/EmailDownloadAttachment.ts
+++ b/nodes/Imap/operations/email/functions/EmailDownloadAttachment.ts
@@ -1,8 +1,9 @@
-import { DownloadObject, ImapFlow } from "imapflow";
+import { DownloadObject, FetchQueryObject, ImapFlow } from "imapflow";
 import { IExecuteFunctions, INodeExecutionData, NodeApiError } from "n8n-workflow";
 import { IResourceOperationDef } from "../../../utils/CommonDefinitions";
 import { getMailboxPathFromNodeParameter, parameterSelectMailbox } from "../../../utils/SearchFieldParameters";
 import { ImapFlowErrorCatcher } from "../../../utils/ImapUtils";
+import { getEmailPartsInfoRecursive } from "../../../utils/EmailParts";
 
 export const downloadAttachmentOperation: IResourceOperationDef = {
   operation: {
@@ -22,59 +23,122 @@ export const downloadAttachmentOperation: IResourceOperationDef = {
       description: 'UID of the email to download',
     },
     {
-      displayName: 'Attachment Part ID',
+      displayName: 'All Attachments',
+      name: 'allAttachments',
+      type: 'boolean',
+      default: false,
+      description: 'Whether to download all attachments',
+    },
+    {
+      displayName: 'Attachment Part IDs',
       name: 'partId',
       type: 'string',
       default: '',
       required: true,
-      description: 'ID of the part to download',
-      hint: 'Part ID can be found in the email "attachmentsInfo" property',
+      description: 'Comma-separated list of attachment part IDs to download',
+      hint: 'Part IDs can be found in the email "attachmentsInfo" property',
+      displayOptions: {
+        show: {
+          allAttachments: [
+            false,
+          ],
+        },
+      },
     },
   ],
   async executeImapAction(context: IExecuteFunctions, itemIndex: number, client: ImapFlow): Promise<INodeExecutionData[] | null> {
-    var returnData: INodeExecutionData[] = [];
+
+    var returnItem: INodeExecutionData = {
+      json: {},
+      binary: {},
+    };
+    var jsonAttachments: any[] = [];
+    var attachmentCounter = 0;
 
     const mailboxPath = getMailboxPathFromNodeParameter(context, itemIndex);
 
     await client.mailboxOpen(mailboxPath, { readOnly: true });
 
     const emailUid = context.getNodeParameter('emailUid', itemIndex) as string;
-    const partId = context.getNodeParameter('partId', itemIndex) as string;
+    const allAttachments = context.getNodeParameter('allAttachments', itemIndex) as boolean;
 
-    context.logger?.info(`Downloading attachment "${partId}" from email "${emailUid}"`);
+    let partsToDownload: string[] = [];
 
-
-    // start catching errors
-    ImapFlowErrorCatcher.getInstance().startErrorCatching();
-
-    const resp : DownloadObject = await client.download(emailUid, partId, {
-      uid: true,
-    });
-    if (!resp.meta) {
-      // get IMAP errors
-      const internalImapErrors = ImapFlowErrorCatcher.getInstance().stopAndGetErrors();
-      var errorDetails = "";
-      if (internalImapErrors.length > 0) {
-        errorDetails = "IMAP server responded: \n" + internalImapErrors.join(", \n");
+    if (allAttachments) {
+      // get attachments info from the email
+      const query: FetchQueryObject = {
+        uid: true,
+        bodyStructure: true,
+      };
+      const emailInfo = await client.fetchOne(emailUid, query, { uid: true });
+      if (emailInfo.bodyStructure) {
+        const partsInfo = getEmailPartsInfoRecursive(context, emailInfo.bodyStructure);
+        for (const partInfo of partsInfo) {
+          context.logger?.debug(`Attachment part info: ${JSON.stringify(partInfo)}`);
+          if (partInfo.disposition === 'attachment') {
+            partsToDownload.push(partInfo.partId);
+          }
+        }
+      } else{
+        context.logger?.warn(`IMAP server has not returned email body structure for email "${emailUid}"`);
       }
-
-      context.logger?.error(`IMAP server has not returned attachment info: ${errorDetails}`);
-
-      throw new NodeApiError(context.getNode(), {}, {
-        message: "IMAP server has not returned attachment info",
-        description: errorDetails,
-      });
+      if (partsToDownload.length > 0) {
+        context.logger?.info(`Downloading all attachments from email "${emailUid}": ${partsToDownload.join(', ')}`);
+      } else {
+        context.logger?.warn(`Email "${emailUid}" does not have any attachments`);
+      }
+    } else {
+      const partId = context.getNodeParameter('partId', itemIndex) as string;
+      // split by comma and remove spaces
+      const parts = partId.split(',').map((part) => part.trim());
+      partsToDownload.push(...parts);
+      context.logger?.info(`Downloading some attachments from email "${emailUid}": ${partsToDownload.join(', ')}`);
     }
-    const binaryData = await context.helpers.prepareBinaryData(resp.content, resp.meta.filename, resp.meta.contentType);
-    context.logger?.info(`Attachment downloaded: ${binaryData.data.length} bytes`);
 
-    returnData.push({
-      json: resp.meta,
-      binary: {
-        attachment: binaryData,
-      },
-    });
+    for (const partId of partsToDownload) {
 
-    return returnData;
+      context.logger?.info(`Downloading attachment "${partId}" from email "${emailUid}"`);
+
+
+      // start catching errors
+      ImapFlowErrorCatcher.getInstance().startErrorCatching();
+
+      const resp : DownloadObject = await client.download(emailUid, partId, {
+        uid: true,
+      });
+      if (!resp.meta) {
+        // get IMAP errors
+        const internalImapErrors = ImapFlowErrorCatcher.getInstance().stopAndGetErrors();
+        var errorDetails = "";
+        if (internalImapErrors.length > 0) {
+          errorDetails = "IMAP server responded: \n" + internalImapErrors.join(", \n");
+        }
+
+        context.logger?.error(`IMAP server has not returned attachment info: ${errorDetails}`);
+
+        throw new NodeApiError(context.getNode(), {}, {
+          message: "IMAP server has not returned attachment info",
+          description: errorDetails,
+        });
+      }
+      const binaryData = await context.helpers.prepareBinaryData(resp.content, resp.meta.filename, resp.meta.contentType);
+      context.logger?.info(`Attachment downloaded: ${binaryData.data.length} bytes`);
+
+      const fieldName = `attachment_${attachmentCounter}`;
+      attachmentCounter++;
+
+      const jsonAttachmentInfo = {
+        partId: partId,
+        binaryFieldName: fieldName,
+        ...resp.meta,
+      };
+      jsonAttachments.push(jsonAttachmentInfo);
+
+      returnItem.binary![fieldName] = binaryData;
+    }
+
+    // add attachments info to the return item
+    returnItem.json!.attachments = jsonAttachments;
+    return [returnItem];
   },
 };

--- a/nodes/Imap/utils/EmailParts.ts
+++ b/nodes/Imap/utils/EmailParts.ts
@@ -1,0 +1,44 @@
+import { IExecuteFunctions } from "n8n-workflow";
+
+export interface EmailPartInfo {
+  partId: string;
+  filename?: string;
+  type: string;
+  encoding: string;
+  size: number;
+  disposition?: string;
+  parameters?: [string, string];
+}
+
+// get the parts info from the body structure
+export function getEmailPartsInfoRecursive(context: IExecuteFunctions, bodyStructure: any): EmailPartInfo[] {
+  var partsInfo: EmailPartInfo[] = [];
+
+  if (bodyStructure.childNodes) {
+    for (const childNode of bodyStructure.childNodes) {
+      // process only if "size" is present
+      if ("size" in childNode) {
+        var partInfo: EmailPartInfo = {
+          partId: childNode.part,
+          type: childNode.type,
+          encoding: childNode.encoding,
+          size: childNode.size,
+        };
+        if ("disposition" in childNode) {
+          partInfo.disposition = childNode.disposition;
+          if (childNode.disposition === 'attachment') {
+            partInfo.filename = childNode.dispositionParameters?.filename;
+          }
+        }
+        partsInfo.push(partInfo);
+      }
+
+      // check if there are child nodes
+      if (childNode.childNodes) {
+        // recurse
+        partsInfo = partsInfo.concat(getEmailPartsInfoRecursive(context, childNode));
+      }
+    }
+  }
+  return partsInfo;
+}


### PR DESCRIPTION
BREAKING CHANGE: The downloadAttachment node output is changed. Each output item could now contain multiple binary fields named "attachment_0", "attachment_1", etc. Previously, there was only one binary field per output item named "attachment".