### PR TITLE
Enhance error handling in IMAP node with continue on fail option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-imap",
-  "version": "2.8.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-imap",
-      "version": "2.8.0",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "imapflow": "^1.0.188",


### PR DESCRIPTION
Improve error handling in the IMAP node to allow operations to continue even when errors occur.