### PR TITLE
fix(email): preserve ImapFlow Set flags in Get Many output

### DIFF
--- a/nodes/Imap/operations/email/functions/EmailGetList.ts
+++ b/nodes/Imap/operations/email/functions/EmailGetList.ts
@@ -31,6 +31,23 @@ function streamToString(stream: Readable): Promise<string> {
   });
 }
 
+function serializeImapFetchValue(_key: string, value: unknown): unknown {
+  if (value instanceof Set) {
+    return Array.from(value);
+  }
+  if (value instanceof Map) {
+    return Object.fromEntries(value);
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  return value;
+}
+
+function cloneImapFetchMessageForJson(email: FetchMessageObject): any {
+  return JSON.parse(JSON.stringify(email, serializeImapFetchValue));
+}
+
 
 export const getEmailsListOperation: IResourceOperationDef = {
   operation: {
@@ -205,7 +222,7 @@ export const getEmailsListOperation: IResourceOperationDef = {
     // process the emails
     for (const email of emailsList) {
       logger.info(`  ${email.uid}`);
-      var item_json = JSON.parse(JSON.stringify(email));
+      var item_json = cloneImapFetchMessageForJson(email);
 
       // add mailbox path to the item
       item_json.mailboxPath = mailboxPath;

--- a/test/WithImapflowMock/operations/EmailGetList.test.ts
+++ b/test/WithImapflowMock/operations/EmailGetList.test.ts
@@ -120,7 +120,7 @@ describe('EmailGetList', () => {
             subject: 'Test Email 1',
             from: [{ name: 'John Doe', address: 'john@example.com' }],
           },
-          flags: ['\\Seen', '\\Flagged'],
+          flags: new Set(['\\Seen', '\\Flagged']),
         },
       ];
       

--- a/test/WithImapflowMock/operations/EmailGetList.test.ts
+++ b/test/WithImapflowMock/operations/EmailGetList.test.ts
@@ -153,6 +153,176 @@ describe('EmailGetList', () => {
       }, { uid: true });
     });
 
+    it('should serialize non-JSON ImapFlow fetch values in Get Many output', async () => {
+      // Arrange
+      const paramValues = {
+        mailboxPath: { value: 'INBOX' }, emailDateRange: {}, emailFlags: {}, emailSearchFilters: {},
+        searchCriteria: 'ALL',
+        limit: 50,
+        includeParts: [EmailParts.Flags],
+      };
+      const context = createNodeParametersCheckerMock(getEmailsListOperation.parameters, paramValues);
+
+      const mockEmailData = [
+        {
+          uid: 123,
+          envelope: {
+            subject: 'Test Email 1',
+            from: [{ name: 'John Doe', address: 'john@example.com' }],
+          },
+          flags: new Set(['\\Seen', '\\Flagged']),
+          labels: new Map<string, unknown>([
+            ['category', 'primary'],
+            ['important', true],
+          ]),
+          modseq: BigInt('9007199254740993'),
+        },
+      ];
+
+      const mockFetchAsyncIterator = {
+        [Symbol.asyncIterator]: jest.fn().mockReturnValue({
+          next: jest.fn()
+            .mockResolvedValueOnce({ value: mockEmailData[0], done: false })
+            .mockResolvedValueOnce({ done: true }),
+        }),
+      };
+
+      mockImapflow.fetch = jest.fn().mockReturnValue(mockFetchAsyncIterator);
+
+      const originalBigIntToJson = Object.getOwnPropertyDescriptor(BigInt.prototype, 'toJSON');
+      delete (BigInt.prototype as { toJSON?: unknown }).toJSON;
+
+      try {
+        // Act
+        const result = await getEmailsListOperation.executeImapAction(
+          context as IExecuteFunctions,
+          context.logger!,
+          ITEM_INDEX,
+          mockImapflow
+        );
+
+        // Assert
+        expect(result).toBeDefined();
+        expect(result?.length).toBe(1);
+        expect(result![0].json.flags).toEqual(['\\Seen', '\\Flagged']);
+        expect(result![0].json.labels).toEqual({
+          category: 'primary',
+          important: true,
+        });
+        expect(result![0].json.modseq).toBe('9007199254740993');
+      } finally {
+        if (originalBigIntToJson) {
+          Object.defineProperty(BigInt.prototype, 'toJSON', originalBigIntToJson);
+        } else {
+          delete (BigInt.prototype as { toJSON?: unknown }).toJSON;
+        }
+      }
+    });
+
+    it('should serialize nested ImapFlow fetch values in Get Many output', async () => {
+      // Arrange
+      const paramValues = {
+        mailboxPath: { value: 'INBOX' }, emailDateRange: {}, emailFlags: {}, emailSearchFilters: {},
+        searchCriteria: 'ALL',
+        limit: 50,
+        includeParts: [],
+      };
+      const context = createNodeParametersCheckerMock(getEmailsListOperation.parameters, paramValues);
+
+      const mockEmailData = [
+        {
+          uid: 123,
+          envelope: {
+            subject: 'Test Email 1',
+            from: [{ name: 'John Doe', address: 'john@example.com' }],
+          },
+          metadata: {
+            keywords: new Set(['inbox', 'work']),
+            counters: new Map<string, unknown>([
+              ['highestModseq', BigInt('42')],
+              ['seenUids', new Set([123, 124])],
+            ]),
+          },
+        },
+      ];
+
+      const mockFetchAsyncIterator = {
+        [Symbol.asyncIterator]: jest.fn().mockReturnValue({
+          next: jest.fn()
+            .mockResolvedValueOnce({ value: mockEmailData[0], done: false })
+            .mockResolvedValueOnce({ done: true }),
+        }),
+      };
+
+      mockImapflow.fetch = jest.fn().mockReturnValue(mockFetchAsyncIterator);
+
+      // Act
+      const result = await getEmailsListOperation.executeImapAction(
+        context as IExecuteFunctions,
+        context.logger!,
+        ITEM_INDEX,
+        mockImapflow
+      );
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result?.length).toBe(1);
+      expect(result![0].json.metadata).toEqual({
+        keywords: ['inbox', 'work'],
+        counters: {
+          highestModseq: '42',
+          seenUids: [123, 124],
+        },
+      });
+    });
+
+    it('should serialize empty Set and Map values without dropping their shape', async () => {
+      // Arrange
+      const paramValues = {
+        mailboxPath: { value: 'INBOX' }, emailDateRange: {}, emailFlags: {}, emailSearchFilters: {},
+        searchCriteria: 'ALL',
+        limit: 50,
+        includeParts: [EmailParts.Flags],
+      };
+      const context = createNodeParametersCheckerMock(getEmailsListOperation.parameters, paramValues);
+
+      const mockEmailData = [
+        {
+          uid: 123,
+          envelope: {
+            subject: 'Test Email 1',
+            from: [{ name: 'John Doe', address: 'john@example.com' }],
+          },
+          flags: new Set(),
+          labels: new Map(),
+        },
+      ];
+
+      const mockFetchAsyncIterator = {
+        [Symbol.asyncIterator]: jest.fn().mockReturnValue({
+          next: jest.fn()
+            .mockResolvedValueOnce({ value: mockEmailData[0], done: false })
+            .mockResolvedValueOnce({ done: true }),
+        }),
+      };
+
+      mockImapflow.fetch = jest.fn().mockReturnValue(mockFetchAsyncIterator);
+
+      // Act
+      const result = await getEmailsListOperation.executeImapAction(
+        context as IExecuteFunctions,
+        context.logger!,
+        ITEM_INDEX,
+        mockImapflow
+      );
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result?.length).toBe(1);
+      expect(result![0].json.flags).toEqual([]);
+      expect(result![0].json.labels).toEqual({});
+    });
+
     it('should get emails with size when includeParts includes size', async () => {
       // Arrange
       const paramValues = {


### PR DESCRIPTION
ImapFlow returns flags as a JavaScript Set. JSON.stringify serializes Set values as {}, so Get Many could output flags as an empty object instead of the actual flag names. Convert Set values to arrays while cloning fetched messages for n8n JSON output, and update the flags test to match ImapFlow behavior.